### PR TITLE
Issue #85: All usage of Chunk::chunk_date is removed

### DIFF
--- a/app/Http/Resources/ChunkResource.php
+++ b/app/Http/Resources/ChunkResource.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property int $id Chunk ID
  * @property string $chunk_id Chunk id as given by source
  * @property string $sink_id
- * @property string|null $chunk_date What moment in time this chunk belongs to
  * @property int|null $sink_file_id File assocciated with fetched chunk
  * @property string $fetch_status Raw data retrieval status
  * @property int|null $fetch_size Total size of fetched files/data
@@ -47,7 +46,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @method static Builder|Chunk newQuery()
  * @method static Builder|Chunk notInBatch()
  * @method static Builder|Chunk query()
- * @method static Builder|Chunk whereChunkDate($value)
  * @method static Builder|Chunk whereChunkId($value)
  * @method static Builder|Chunk whereCreatedAt($value)
  * @method static Builder|Chunk whereFetchBatch($value)

--- a/app/Models/Chunk.php
+++ b/app/Models/Chunk.php
@@ -19,7 +19,6 @@ use Ragnarok\Sink\Models\SinkFile;
  * @property int $id Chunk ID
  * @property string $chunk_id Chunk id as given by source
  * @property string $sink_id
- * @property string|null $chunk_date What moment in time this chunk belongs to
  * @property int|null $sink_file_id File assocciated with fetched chunk
  * @property string $fetch_status Raw data retrieval status
  * @property int|null $fetch_size Total size of fetched files/data
@@ -54,7 +53,6 @@ use Ragnarok\Sink\Models\SinkFile;
  * @method static Builder|Chunk newQuery()
  * @method static Builder|Chunk notInBatch()
  * @method static Builder|Chunk query()
- * @method static Builder|Chunk whereChunkDate($value)
  * @method static Builder|Chunk whereChunkId($value)
  * @method static Builder|Chunk whereCreatedAt($value)
  * @method static Builder|Chunk whereFetchBatch($value)
@@ -88,7 +86,6 @@ class Chunk extends Model
         'id',
         'sink_id',
         'chunk_id',
-        'chunk_date',
         'sink_file_id',
         'fetch_status',
         'fetch_size',

--- a/app/Services/SinkHandler.php
+++ b/app/Services/SinkHandler.php
@@ -116,7 +116,6 @@ class SinkHandler
             /** @var SinkFile $file */
             $file = $this->src->fetch($chunk->chunk_id);
             $chunk->sink_file_id = $file->id;
-            $chunk->chunk_date = $this->src->getChunkDate($chunk->chunk_id);
             $chunk->fetch_size = $file->size;
             $chunk->fetch_version = $file->checksum;
         }, $chunk, 'fetch');

--- a/database/migrations/2023_06_07_100000_ragnarok_tables.php
+++ b/database/migrations/2023_06_07_100000_ragnarok_tables.php
@@ -25,7 +25,6 @@ return new class extends Migration
             $table->id()->comment('Chunk ID');
             $table->char('sink_id', 64);
             $table->char('chunk_id', 64)->comment('Chunk id as given by source');
-            $table->dateTime('chunk_date')->nullable()->comment('What moment in time this chunk belongs to');
             $table->unsignedBigInteger('sink_file_id')->nullable()->comment('File assocciated with fetched chunk');
             $table->enum('fetch_status', $statusValues)->default('new')->comment('Raw data retrieval status');
             $table->unsignedInteger('fetch_size')->nullable()->comment('Total size of fetched files/data');


### PR DESCRIPTION
Since we still haven't created a release, there is no explicit migration for the db modifications. You can drop the column with
```sql
alter table ragnarok_chunks drop column chunk_date;
```
