### PR TITLE
feat: show documentation as popup on sink landing page

### DIFF
--- a/app/Models/Sink.php
+++ b/app/Models/Sink.php
@@ -40,7 +40,7 @@ class Sink extends Model
     protected $table = 'ragnarok_sinks';
     protected $keyType = 'string';
     protected $casts = ['single_state' => 'boolean'];
-    protected $appends = ['is_live'];
+    protected $appends = ['is_live', 'has_doc'];
 
     public function chunks(): HasMany
     {
@@ -55,5 +55,12 @@ class Sink extends Model
     public function isLive(): Attribute
     {
         return Attribute::make(get: fn(mixed $value, array $attr) => $attr['status'] === 'live');
+    }
+
+    public function hasDoc(): Attribute
+    {
+        return Attribute::make(
+            get: fn() => (new ($this->impl_class)())->getDocumentation() !== null
+        );
     }
 }

--- a/resources/js/Pages/Partials/SinkDocs.vue
+++ b/resources/js/Pages/Partials/SinkDocs.vue
@@ -15,5 +15,5 @@ onMounted(async () => {
 
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div v-html="docs" />
+  <div v-html="docs" style="max-width: 800px"/>
 </template>

--- a/resources/js/Pages/Partials/SinkDocs.vue
+++ b/resources/js/Pages/Partials/SinkDocs.vue
@@ -14,7 +14,6 @@ onMounted(async () => {
 </script>
 
 <template>
-  <!-- eslint-disable vue/no-v-html -->
+  <!-- eslint-disable-next-line vue/no-v-html -->
   <div v-html="docs" />
-  <!-- eslint-enable -->
 </template>

--- a/resources/js/Pages/Partials/SinkDocs.vue
+++ b/resources/js/Pages/Partials/SinkDocs.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+
+const props = defineProps({
+    sinkId: { type: String, required: true },
+});
+
+const docs = ref();
+
+onMounted(async () => {
+    const result = await axios.get(`/api/sinks/${props.sinkId}/getDoc`);
+    docs.value = result.status === 200 ? result.data : 'No documentation provided';
+});
+</script>
+
+<template>
+  <!-- eslint-disable vue/no-v-html -->
+  <div v-html="docs" />
+  <!-- eslint-enable -->
+</template>

--- a/resources/js/Pages/SinkStatus.vue
+++ b/resources/js/Pages/SinkStatus.vue
@@ -592,7 +592,7 @@ onMounted(() => {
     <v-dialog v-model="docsDialog" max-width="90%" max-height="80%">
         <v-card>
         <v-toolbar color="primary">
-            <v-toolbar-title>Documentation for '{{ props.sink.id }}'</v-toolbar-title>
+               <v-toolbar-title>Documentation for '{{ props.sink.id }}'</v-toolbar-title>
             <v-spacer />
             <v-btn icon="mdi-close" @click="docsDialog = false" />
         </v-toolbar>

--- a/resources/js/Pages/SinkStatus.vue
+++ b/resources/js/Pages/SinkStatus.vue
@@ -590,16 +590,16 @@ onMounted(() => {
     </v-data-table-server>
 
     <v-dialog v-model="docsDialog" max-width="90%" max-height="80%">
-        <v-card>
+      <v-card>
         <v-toolbar color="primary">
-               <v-toolbar-title>Documentation for '{{ props.sink.id }}'</v-toolbar-title>
-            <v-spacer />
+          <v-toolbar-title>Documentation for '{{ props.sink.id }}'</v-toolbar-title>
+          <v-spacer />
             <v-btn icon="mdi-close" @click="docsDialog = false" />
         </v-toolbar>
         <v-card-text>
-            <sink-docs :sink-id="props.sink.id" />
+          <sink-docs :sink-id="props.sink.id" />
         </v-card-text>
-        </v-card>
+      </v-card>
     </v-dialog>
 
     <confirm-dialog v-model="confDiags.rmChunk" @confirmed="singleChunkOperation(targetChunkId, 'deleteFetched')">

--- a/resources/js/Pages/SinkStatus.vue
+++ b/resources/js/Pages/SinkStatus.vue
@@ -358,7 +358,12 @@ onMounted(() => {
             <v-col v-if="showOp" class="text-grey">
               {{ selectionCount }} selected
             </v-col>
-            <v-btn icon variant="plain" @click="showDocs()">
+            <v-btn
+              v-if="props.sink.has_doc"
+              icon
+              variant="plain"
+              @click="showDocs()"
+            >
               <v-icon icon="mdi-information" />
               <v-tooltip activator="parent" location="top">
                 Load documentation

--- a/resources/js/Pages/SinkStatus.vue
+++ b/resources/js/Pages/SinkStatus.vue
@@ -4,6 +4,7 @@ import ConfirmDialog from '@/Components/ConfirmDialog.vue';
 import BatchOperations from '@/Components/BatchOperations.vue';
 import ChunkError from '@/Pages/Partials/ChunkError.vue';
 import ChunkMenu from '@/Pages/Partials/ChunkMenu.vue';
+import SinkDocs from '@/Pages/Partials/SinkDocs.vue';
 import { permissionProps, usePermissions } from '@/composables/permissions';
 import useStatus from '@/composables/chunks';
 import {
@@ -130,6 +131,13 @@ watch(filterParams, touchSearch);
 function clearChunkId() {
     filterChunkIdInput(null);
     filterChunkIdInput.flush();
+}
+
+// Sink documentation
+const docsDialog = ref(false);
+
+function showDocs() {
+    docsDialog.value = true;
 }
 
 function resetSelection() {
@@ -350,6 +358,12 @@ onMounted(() => {
             <v-col v-if="showOp" class="text-grey">
               {{ selectionCount }} selected
             </v-col>
+            <v-btn icon variant="plain" @click="showDocs()">
+              <v-icon icon="mdi-information" />
+              <v-tooltip activator="parent" location="top">
+                Load documentation
+              </v-tooltip>
+            </v-btn>
             <v-btn v-if="haveOperations" icon @click="showOp = !showOp">
               <v-icon :icon="showOp ? 'mdi-chevron-up' : 'mdi-chevron-down'" />
             </v-btn>
@@ -574,6 +588,19 @@ onMounted(() => {
         </tr>
       </template>
     </v-data-table-server>
+
+    <v-dialog v-model="docsDialog" max-width="90%" max-height="80%">
+        <v-card>
+        <v-toolbar color="primary">
+            <v-toolbar-title>Documentation for '{{ props.sink.id }}'</v-toolbar-title>
+            <v-spacer />
+            <v-btn icon="mdi-close" @click="docsDialog = false" />
+        </v-toolbar>
+        <v-card-text>
+            <sink-docs :sink-id="props.sink.id" />
+        </v-card-text>
+        </v-card>
+    </v-dialog>
 
     <confirm-dialog v-model="confDiags.rmChunk" @confirmed="singleChunkOperation(targetChunkId, 'deleteFetched')">
       <p>This will permamently remove local copy of raw, stage 1 data.</p>

--- a/resources/js/Pages/SinkStatus.vue
+++ b/resources/js/Pages/SinkStatus.vue
@@ -594,7 +594,7 @@ onMounted(() => {
         <v-toolbar color="primary">
           <v-toolbar-title>Documentation for '{{ props.sink.id }}'</v-toolbar-title>
           <v-spacer />
-            <v-btn icon="mdi-close" @click="docsDialog = false" />
+          <v-btn icon="mdi-close" @click="docsDialog = false" />
         </v-toolbar>
         <v-card-text>
           <sink-docs :sink-id="props.sink.id" />


### PR DESCRIPTION
Presents SINK.md (or file specified by actual sink implementation) formatted as HTML on sink landing page.

It is presented as a popup. There is an information icon to the right on the landing page menu bar which will open the popup.

Will display "No documentation provided" if API cant find a documentation file