### PR TITLE
feat: Add mechanism for re-fetching based on sink's cron entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+### Added
+- Cogs making re-fetch API in SinkBase work.
+
 ## [0.1.0] – 2022-04-18
 
 This initial release is based on Laravel jetstream using the inertia

--- a/app/Services/RagnarokApi.php
+++ b/app/Services/RagnarokApi.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Sink;
+use App\Models\Chunk;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Console\Scheduling\Schedule;
@@ -56,12 +57,8 @@ class RagnarokApi
             if (! $handler->sink->is_live) {
                 return;
             }
-            $importEvent = $schedule->call([$handler, 'importNewChunks']);
-            if ($handler->src->cron) {
-                $importEvent->cron($handler->src->cron);
-            } else {
-                $importEvent->dailyAt('05:00');
-            }
+            $this->setupImportSchedule($handler, $schedule);
+            $this->setupRefetchSchedule($handler, $schedule);
         });
         return $this;
     }
@@ -73,5 +70,40 @@ class RagnarokApi
     {
         $this->getSinkHandlers()->each(fn (SinkHandler $handler) => $handler->importNewChunks());
         return $this;
+    }
+
+    /**
+     * Setup scheduled import for sink.
+     */
+    protected function setupImportSchedule(SinkHandler $handler, Schedule $schedule): void
+    {
+        $importEvent = $schedule->call([$handler, 'importNewChunks']);
+        if ($handler->src->cron) {
+            $importEvent->cron($handler->src->cron);
+        } else {
+            $importEvent->dailyAt('05:00');
+        }
+    }
+
+    /**
+     * Setup scheduled re-fetch of chunks from sink.
+     */
+    protected function setupRefetchSchedule(SinkHandler $handler, Schedule $schedule): void
+    {
+        if (empty($handler->src->cronRefetch)) {
+            return;
+        }
+        $schedule->call(function () use ($handler) {
+            list ($fromChunkId, $toChunkId) = $handler->src->refetchIdRange();
+            if (empty($fromChunkId || empty($toChunkId))) {
+                return;
+            }
+            $ids = Chunk::select('chunk_id')
+                ->where('sink_id', $handler->src::$id)
+                ->where('chunk_id', '>=', $fromChunkId)
+                ->where('chunk_id', '<=', $toChunkId)
+                ->pluck('chunk_id')->toArray();
+            // $handler->getChunkDispatcher()->setForceFetch()->fetch($ids);
+        })->cron($handler->src->cronRefetch);
     }
 }

--- a/app/Services/RagnarokApi.php
+++ b/app/Services/RagnarokApi.php
@@ -103,7 +103,9 @@ class RagnarokApi
                 ->where('chunk_id', '>=', $fromChunkId)
                 ->where('chunk_id', '<=', $toChunkId)
                 ->pluck('id')->toArray();
-            $handler->getChunkDispatcher()->setForceFetch()->fetch($ids);
+            // By forcing fetch this will be downloaded, and imported only if
+            // they are modified.
+            $handler->getChunkDispatcher()->setForceFetch()->import($ids);
         })->cron($handler->src->cronRefetch);
     }
 }

--- a/app/Services/RagnarokApi.php
+++ b/app/Services/RagnarokApi.php
@@ -78,7 +78,7 @@ class RagnarokApi
     protected function setupImportSchedule(SinkHandler $handler, Schedule $schedule): void
     {
         $importEvent = $schedule->call([$handler, 'importNewChunks']);
-        if ($handler->src->cron) {
+        if ($handler->src->cron !== null) {
             $importEvent->cron($handler->src->cron);
         } else {
             $importEvent->dailyAt('05:00');
@@ -98,12 +98,12 @@ class RagnarokApi
             if (empty($fromChunkId || empty($toChunkId))) {
                 return;
             }
-            $ids = Chunk::select('chunk_id')
+            $ids = Chunk::select('id')
                 ->where('sink_id', $handler->src::$id)
                 ->where('chunk_id', '>=', $fromChunkId)
                 ->where('chunk_id', '<=', $toChunkId)
-                ->pluck('chunk_id')->toArray();
-            // $handler->getChunkDispatcher()->setForceFetch()->fetch($ids);
+                ->pluck('id')->toArray();
+            $handler->getChunkDispatcher()->setForceFetch()->fetch($ids);
         })->cron($handler->src->cronRefetch);
     }
 }


### PR DESCRIPTION
This utilizes re-fetch API in SinkBase. This code has uncommented the actual retrieval of chunks, but the mechanism works (tested with logs and dumps of IDs).